### PR TITLE
Support the new app.memrise.com sub-domain

### DIFF
--- a/MemriseDisableAutoAccept.user.js
+++ b/MemriseDisableAutoAccept.user.js
@@ -4,6 +4,8 @@
 // @description    Disable auto accept feature on Memrise typing test
 // @match          https://www.memrise.com/course/*/garden/*
 // @match          https://www.memrise.com/garden/review/*
+// @match          https://app.memrise.com/course/*/garden/*
+// @match          https://app.memrise.com/garden/review/*
 // @version        1.1.0
 // @updateURL      https://github.com/stream009/greasemonkey_scripts/raw/master/MemriseDisableAutoAccept.user.js
 // @downloadURL    https://github.com/stream009/greasemonkey_scripts/raw/master/MemriseDisableAutoAccept.user.js

--- a/MemriseDisableAutoAccept.user.js
+++ b/MemriseDisableAutoAccept.user.js
@@ -6,7 +6,7 @@
 // @match          https://www.memrise.com/garden/review/*
 // @match          https://app.memrise.com/course/*/garden/*
 // @match          https://app.memrise.com/garden/review/*
-// @version        1.1.0
+// @version        1.1.1
 // @updateURL      https://github.com/stream009/greasemonkey_scripts/raw/master/MemriseDisableAutoAccept.user.js
 // @downloadURL    https://github.com/stream009/greasemonkey_scripts/raw/master/MemriseDisableAutoAccept.user.js
 // @grant          none


### PR DESCRIPTION
Memrise seems to have changed the addresses of their lessons from `https://www.memrise.com/course/*/garden/*` to `https://app.memrise.com/course/*/garden/*` , and the same for review (changing `www` to `app`). This means the script is not called anymore. This change, which simply adds `@match` statements with the new addresses, worked for me. Please make sure I did this correctly in Github.